### PR TITLE
Support timed try_accept for IpcOneShotServer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ futures = { version = "0.1", optional = true }
 crossbeam = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["errhandlingapi", "fileapi", "handleapi", "ioapiset", "memoryapi", "minwindef", "namedpipeapi", "processthreadsapi", "winerror", "winnt"] }
+winapi = { version = "0.3", features = ["errhandlingapi", "fileapi", "handleapi", "ioapiset", "memoryapi", "minwindef", "namedpipeapi", "processthreadsapi", "synchapi", "winerror", "winnt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ description = "A multiprocess drop-in replacement for Rust channels"
 authors = ["The Servo Project Developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/servo/ipc-channel"
+edition = "2015"
 
 [features]
 force-inprocess = []

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -7,6 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! Inter-process communication.
+
 use platform::{self, OsIpcChannel, OsIpcReceiver, OsIpcReceiverSet, OsIpcSender};
 use platform::{OsIpcOneShotServer, OsIpcSelectionResult, OsIpcSharedMemory, OsOpaqueIpcChannel};
 
@@ -447,6 +449,7 @@ pub struct OpaqueIpcReceiver {
     os_receiver: OsIpcReceiver,
 }
 
+/// A server associated with a given name.
 pub struct IpcOneShotServer<T> {
     os_server: OsIpcOneShotServer,
     phantom: PhantomData<T>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 #![cfg_attr(any(feature = "force-inprocess", target_os = "android", target_os = "ios"),
 			feature(mpsc_select))]
 #![cfg_attr(all(feature = "unstable", test), feature(specialization))]
+#![allow(non_fmt_panic)]
 
 #[macro_use]
 extern crate lazy_static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,3 +52,4 @@ pub mod router;
 mod test;
 
 pub use bincode::{Error, ErrorKind};
+pub use ipc::IpcOneShotServer;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -7,6 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! Platform-specific features.
+
 #[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
                                                 target_os = "openbsd",
                                                 target_os = "freebsd")))]

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -1113,6 +1113,7 @@ impl OsIpcReceiver {
                     let mut nbytes: u32 = 0;
                     let ok = GetOverlappedResult(handle.as_raw(), ov.alias_mut().deref_mut(), &mut nbytes, TRUE);
                     if ok == FALSE {
+                        ov.into_inner();
                         return Err(WinError::last("GetOverlappedResult[ConnectNamedPipe]"));
                     }
                     Ok(())


### PR DESCRIPTION
This introduces a timed `try_accept()`  (in contrary to a blocking `accept()`.

Tests are included.